### PR TITLE
Update BlurUIKit dependency to use https url

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "BlurUIKit",
+        "repositoryURL": "https://github.com/TimOliver/BlurUIKit.git",
+        "state": {
+          "branch": null,
+          "revision": "7808a740b1424e4a105c6c9df0aff2f3de7ac7a4",
+          "version": "1.2.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "KeyboardToolbar", targets: ["KeyboardToolbar"]),
     ],
     dependencies: [
-        .package(url: "git@github.com:TimOliver/BlurUIKit.git", from: "1.1.1")
+        .package(url: "https://github.com/TimOliver/BlurUIKit.git", from: "1.1.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
👋  I noticed you started working on iOS26 compatibility - thank you a lot for doing this work!

This PR changes the package dependency to use https instead of ssh, as the later can cause issues in some CI pipelines.

Bonus question: 
Sounds like most of what `BlurUIKit` provides is now [official API](https://developer.apple.com/documentation/uikit/uiscrollview/topedgeeffect). Do you think this dependency can be dropped in the future?

Thank you for maintaining this package!